### PR TITLE
add setup.py;travis;test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,128 @@
-__pycache__/
 .vscode/
 .idea/
 song/
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
 venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   # the first package to install (for every conda install command) otherwise
   # numpy may be automatically upgraded.
 
-  - conda install --yes pip swig numpy pandas scikit-learn
+  # - conda install --yes pip swig numpy pandas scikit-learn
 
   # You can also install some dependencies with pip if not available in conda
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+sudo: required
+language: python
+git:
+  depth: 3
+  quiet: true
+python: 
+  - '3.5'
+  - '3.6'
+
+# before_install:
+
+#   # Here we just install Miniconda, which you shouldn't have to change.
+
+#   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+#   - chmod +x miniconda.sh
+#   - ./miniconda.sh -b
+#   - export PATH=/home/travis/miniconda3/bin:$PATH
+#   - conda update --yes conda
+
+
+install:
+
+  # We just set up a conda environment with the right Python version. This
+  # should not need changing.
+
+  # - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
+  # - source activate test
+
+  # Below, include the dependencies you want to install with conda, optionally
+  # specifying versions used in the matrix above. If you split this into
+  # multiple conda install commands, you should always include numpy=$NUMPY as
+  # the first package to install (for every conda install command) otherwise
+  # numpy may be automatically upgraded.
+
+  - conda install --yes pip swig numpy pandas scikit-learn
+
+  # You can also install some dependencies with pip if not available in conda
+
+  # - pip install ...
+  # if some package depends on numpy, Numpy should be installed with conda.
+  - pip install codecov
+  - pip install -r requirements.txt
+
+script:
+  - python examples/test_api.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # QQMusicAPI
+[![Build Status](https://travis-ci.org/lai-bluejay/QQMusicAPI.svg?branch=master)](https://travis-ci.org/lai-bluejay/QQMusicAPI)
+![PyPI](https://img.shields.io/pypi/v/diego.svg?style=flat)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/lai-bluejay/QQMusicAPI.svg)
 
 ## 支持的版本
 

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+examples/test_api.py was created on 2019/03/29.
+file in :relativeFile
+Author: Charles_Lai
+Email: lai.bluejay@gmail.com
+"""
+from QQMusicAPI import QQMusic
+
+music_list = QQMusic.search('届かない恋')  # 我最喜欢的是学姐版的(茅野愛衣)
+print(type(music_list))
+print(music_list.data)
+print(music_list.page_size)
+print(music_list.total_num)
+print(music_list.keyword)
+next_music_list = music_list.next_page()
+print(next_music_list.cursor_page)
+print(next_music_list.prev_page)
+
+song = music_list.data[0]
+for k, v in song.__dict__.items():
+    print(k, v)
+
+print(song.song_url())

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -6,6 +6,13 @@ file in :relativeFile
 Author: Charles_Lai
 Email: lai.bluejay@gmail.com
 """
+import os
+import sys
+root = os.path.dirname(os.path.abspath(__file__))
+sys.path.append("%s/../.." % root)
+sys.path.append("%s/.." % root)
+sys.path.append(u"{0:s}".format(root))
+
 from QQMusicAPI import QQMusic
 
 music_list = QQMusic.search('届かない恋')  # 我最喜欢的是学姐版的(茅野愛衣)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+QQMusicAPI/setup.py was created on 2019/03/29.
+file in :relativeFile
+Author: Charles_Lai
+Email: lai.bluejay@gmail.com
+"""
+# Note: To use the 'upload' functionality of this file, you must:
+#   $ pip install twine
+
+import io
+import os
+import sys
+from shutil import rmtree
+
+from setuptools import find_packages, setup, Command
+
+# Package meta-data.
+NAME = 'qqmusic-api'
+DESCRIPTION = 'some api about qqmusic'
+URL = 'https://github.com/MeiK-h/QQMusicAPI'
+EMAIL = 'meik2333@gmail.com'
+AUTHOR = 'Meik H'
+REQUIRES_PYTHON = '>=3.5.0'
+VERSION = '0.1'
+
+# What packages are required for this module to be executed?
+REQUIRED = [
+    # 'requests', 'maya', 'records',
+    'requests'
+]
+
+# What packages are optional?
+EXTRAS = {
+    # 'fancy feature': ['django'],
+}
+here = os.path.abspath(os.path.dirname(__file__))
+
+def parse_requirements(REQUIRED, here):
+    with open(os.path.join(here, 'requirements.txt')) as fp:
+        install_reqs = [r.rstrip() for r in fp.readlines()
+                        if not r.startswith('#') and not r.startswith('git+')]
+    new_reqs = [r for r in install_reqs if r not in REQUIRED]
+    REQUIRED += new_reqs
+    return REQUIRED
+REQUIRED = parse_requirements(REQUIRED, here)
+
+# The rest you shouldn't have to touch too much :)
+# ------------------------------------------------
+# Except, perhaps the License and Trove Classifiers!
+# If you do change the License, remember to change the Trove Classifier for that!
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# setup_reqs = ['Cython', 'numpy']
+# with open(os.path.join(here, 'requirements.txt')) as fp:
+#     install_reqs = [r.rstrip() for r in fp.readlines()
+#                     if not r.startswith('#') and not r.startswith('git+')]
+
+
+# Import the README and use it as the long-description.
+# Note: this will only work if 'README.md' is present in your MANIFEST.in file!
+try:
+    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+        long_description = '\n' + f.read()
+except FileNotFoundError:
+    long_description = DESCRIPTION
+
+# Load the package's __version__.py module as a dictionary.
+about = {}
+if not VERSION:
+    project_slug = NAME.lower().replace("-", "_").replace(" ", "_")
+    with open(os.path.join(here, project_slug, '__version__.py')) as f:
+        exec(f.read(), about)
+else:
+    about['__version__'] = VERSION
+
+
+class UploadCommand(Command):
+    """Support setup.py upload."""
+
+    description = 'Build and publish the package.'
+    user_options = []
+
+    @staticmethod
+    def status(s):
+        """Prints things in bold."""
+        print('\033[1m{0}\033[0m'.format(s))
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        try:
+            self.status('Removing previous builds…')
+            rmtree(os.path.join(here, 'dist'))
+        except OSError:
+            pass
+
+        self.status('Building Source and Wheel (universal) distribution…')
+        os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
+
+        self.status('Uploading the package to PyPI via Twine…')
+        os.system('twine upload dist/*')
+
+        self.status('Pushing git tags…')
+        os.system('git tag v{0}'.format(about['__version__']))
+        os.system('git push --tags')
+        
+        sys.exit()
+
+
+# Where the magic happens:
+setup(
+    name=NAME,
+    version=about['__version__'],
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    url=URL,
+    packages=find_packages(exclude=('tests',)),
+    # If your package is a single module, use this instead of 'packages':
+    # py_modules=['mypackage'],
+
+    # entry_points={
+    #     'console_scripts': ['mycli=mymodule:cli'],
+    # },
+    install_requires=REQUIRED,
+    extras_require=EXTRAS,
+    include_package_data=True,
+    license='MIT',
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+    # $ setup.py publish support.
+    cmdclass={
+        'upload': UploadCommand,
+    },
+)


### PR DESCRIPTION
主要变更：
1. 增加`setup.py`，可以使用 `python setup.py upload` 将包发布到pypi上。
> 需要先`pip install twine`
> 同时需要注册和实名认证pypi
> 你可以合了之后自己修改部分文件
2. 引入持续性集成 travis, 现在地址是在我的项目分支上，你可以修改readme


后续其他API一起开发吧~~